### PR TITLE
Kyles hot fix

### DIFF
--- a/greeter/ember-cli-build.js
+++ b/greeter/ember-cli-build.js
@@ -20,7 +20,7 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  app.import('\\bower_components\\bootstrap\\dist\\css\\bootstrap.min.css');
+  app.import('/bower_components/bootstrap/dist/css/bootstrap.min.css');
 
   return app.toTree();
 };


### PR DESCRIPTION
changed the backwards slashes to forward slashes, window/linux issues in reading the slashes. When coding in the future we need to accommodate both operating systems. Need to run 

``` bash
bower install bootstrap 
```
